### PR TITLE
Add tests for clean.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: echo "Action=${{ github.event.action }} Number=${{ github.event.number }} Pull request=${{ github.event.pull_request }} Created=${{ github.event.created }} Ref=${{ github.event.ref }} HEAD Commit message=${{ github.event.head_commit.message }}"
+      - run: echo "Name==${{ github.event_name }} Action=${{ github.event.action }} Number=${{ github.event.number }} Pull request=${{ github.event.pull_request }} Created=${{ github.event.created }} Ref=${{ github.event.ref }} HEAD Commit message=${{ github.event.head_commit.message }}"
 
   lint:
     needs: precheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,17 @@ on:
       - main
 
 jobs:
+  precheck:
+    runs-on: ubuntu-latest
+
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "${{ github.event }}"
+
   lint:
+    needs: precheck
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -37,6 +47,8 @@ jobs:
         run: hatch run lint:all
 
   typecheck:
+    needs: precheck
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -61,6 +73,8 @@ jobs:
         run: hatch run type:typecheck
 
   test-pyproject-init:
+    needs: precheck
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -85,6 +99,8 @@ jobs:
         run: hatch run test:pyproject-init
 
   test-clean:
+    needs: precheck
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -109,6 +125,8 @@ jobs:
         run: hatch run test:clean
 
   coverage:
+    needs: precheck
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: echo "${{ github.event }}"
+      - run: echo "Action=${{ github.event.action }} Number=${{ github.event.number }} Pull request=${{ github.event.pull_request }} Created=${{ github.event.created }} Ref=${{ github.event.ref }} HEAD Commit message=${{ github.event.head_commit.message }}"
 
   lint:
     needs: precheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,11 @@ jobs:
   precheck:
     runs-on: ubuntu-latest
 
+    if: github.event_name == 'pull_request' || (github.event_name != 'pull_request' && !contains(github.event.head_commit.message, '[skip-ci]'))
 
     steps:
       - uses: actions/checkout@v4
-      - run: echo "Name==${{ github.event_name }} Action=${{ github.event.action }} Number=${{ github.event.number }} Pull request=${{ github.event.pull_request }} Created=${{ github.event.created }} Ref=${{ github.event.ref }} HEAD Commit message=${{ github.event.head_commit.message }}"
+      - run: echo "${{ github.event_name }}"
 
   lint:
     needs: precheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run typecheck
         run: hatch run type:typecheck
 
-  test:
+  test-pyproject-init:
     runs-on: ubuntu-latest
 
     strategy:
@@ -82,7 +82,31 @@ jobs:
         run: hatch env create test && hatch run pip install -e .
 
       - name: Run tests
-        run: hatch run test:test
+        run: hatch run test:pyproject-init
+
+  test-clean:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Install dependencies
+        run: hatch env create test && hatch run pip install -e .
+
+      - name: Run tests
+        run: hatch run test:clean
 
   coverage:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,9 @@ dependencies = [
 ]
 
 [tool.hatch.envs.test.scripts]
-test = "pytest {args:tests}"
+all = "pytest {args:tests}"
+pyproject-init = "pytest tests/test_pyproject_init.py {args:tests}"
+clean = "pytest tests/test_clean.py {args:tests}"
 
 [tool.hatch.envs.coverage]
 dependencies = [
@@ -86,7 +88,9 @@ dependencies = [
 ]
 
 [tool.hatch.envs.coverage.scripts]
-cov = "pytest --cov=pyproject_init --cov-report=term-missing --cov-report=html {args:tests}"
+cov-html = "pytest --cov=pyproject_init --cov-report=term-missing --cov-report=html {args:tests}"
+cov-xml= "pytest --cov=pyproject_init --cov-report=term-missing --cov-report=xml {args:tests}"
+cov = ["cov-html"]
 
 [tool.coverage.run]
 source_pkgs = ["pyproject_init", "tests", "scripts"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ select = [
 ignore = [
   "D100", "D104", "D105", "D106", "D107", "D203", "D213", "D406", "D407", # Docstring rules
   "ANN101", "ANN102", # missing type annotation for self, cls
+  "T201", # print
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,6 @@ select = [
 ignore = [
   "D100", "D104", "D105", "D106", "D107", "D203", "D213", "D406", "D407", # Docstring rules
   "ANN101", "ANN102", # missing type annotation for self, cls
-  "T201", # print
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -121,9 +121,9 @@ def rmtree_safe(path: Path | str) -> int:
         output.debug(f"Removing directory: {dir_path}")
         try:
             shutil.rmtree(dir_path)
+            dir_removed += 1
         except OSError as e:
             output.error(f"Error removing directory {dir_path}: {e}")
-        dir_removed += 1
     elif dir_path.exists():
         output.warning(f'"{dir_path}" exists but is not a directory. Skipping rmtree.')
     else:
@@ -147,9 +147,9 @@ def remove_file_safe(path: Path | str) -> int:
         output.debug(f"Removing file: {dir_path}")
         try:
             dir_path.unlink()
+            file_removed += 1
         except OSError as e:
             output.error(f"Error removing file {dir_path}: {e}")
-        file_removed += 1
     elif dir_path.exists():
         output.warning(f'"{dir_path}" exists but is not a file. Skipping file removal.')
     else:

--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -2,7 +2,6 @@ import enum
 import inspect
 import logging
 import shutil
-import sys
 from pathlib import Path
 
 import click
@@ -167,13 +166,29 @@ def remove_file_safe(path: Path | str) -> int:
     help="Logging level.",
 )
 def main(log_level: LogLevel) -> None:
+    """Run main function for `clean.py`.
+
+    Args:
+        log_level (LogLevel): _description_
+
+    Raises:
+        NotADirectoryError: IF `PROJECT_DIR` is not a directory or doesn't exist.
+
+    """
+    if not PROJECT_DIR.is_dir():
+        raise NotADirectoryError(f'"{PROJECT_DIR.absolute()}" is not a valid directory')
+    clean(log_level, PROJECT_DIR)
+
+
+def clean(log_level: LogLevel, root_path: Path, is_forced: bool = False) -> None:
     """Run main function for clean.py.
 
     Args:
         log_level (LogLevel): Logging level.
+        root_path (Path): Root directory to clean from (used for testing clean.py).
+        is_forced (bool): Force execution and skip prompting (not recommended).
 
     """
-    root_path: Path = PROJECT_DIR
     level: int = LOG_LEVELS[log_level]
     logger.setLevel(level)
     output.set_logging_level(level)
@@ -211,6 +226,4 @@ def main(log_level: LogLevel) -> None:
 
 
 if __name__ == "__main__":
-    if not PROJECT_DIR.is_dir():
-        raise NotADirectoryError(f'"{PROJECT_DIR.absolute()}" is not a valid directory')
     main()

--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -1,4 +1,5 @@
 import enum
+import inspect
 import logging
 import shutil
 import sys
@@ -122,9 +123,13 @@ def main(log_level: LogLevel) -> None:
 
     logger.info(f"Cleaning directory: {root_path}")
 
-    do_proceed: bool = input("Proceed? (y/N): ").lower().startswith("y")
-    if not do_proceed:
-        return
+    pytest_is_invoking: bool = any(
+        "pytest" in frame.function for frame in inspect.stack()
+    )
+    if not pytest_is_invoking and not is_forced:
+        do_proceed: bool = input("Proceed? (y/N): ").lower().startswith("y")
+        if not do_proceed:
+            return
 
     num_files: int = 0
     num_dirs: int = 0

--- a/scripts/clean.py
+++ b/scripts/clean.py
@@ -44,6 +44,7 @@ DIRS_TO_CLEAN = [
     "build",
     "dist",
     ".hatch",
+    "htmlcov",
 ]
 
 FILES_TO_CLEAN = [

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -9,10 +9,10 @@ from scripts.clean import LogLevel
 
 @pytest.fixture(scope="function")
 def runner() -> CliRunner:
-    """Fixture to provide a CliRunner instance.
+    """Fixture to provide a `CliRunner` instance.
 
     Returns:
-        CliRunner: instance of CliRunner class.
+        CliRunner: instance of `CliRunner` class.
 
     """
     return CliRunner()
@@ -20,13 +20,13 @@ def runner() -> CliRunner:
 
 @pytest.fixture(scope="function")
 def tmp_path(tmp_path: Path) -> Path:
-    """Provide `pytest`'s tmp_path with directories and files to clean.
+    """Provide `pytest`'s `tmp_path` fixture with directories and files to clean.
 
     Args:
-        tmp_path (Path): `pytest`'s tmp_path Path fixture.
+        tmp_path (Path): `pytest`'s `tmp_path` fixture.
 
     Returns:
-        Path: tmp_path containing newly created directories and files.
+        Path: `tmp_path` containing newly created directories and files.
 
     """
     directories: list[str] = clean.DIRS_TO_CLEAN.copy()

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -211,6 +211,7 @@ def test_clean_errors(
     """
     for item in tmp_path.iterdir():
         item.chmod(stat.S_IREAD)
+    tmp_path.chmod(stat.S_IREAD | stat.S_IEXEC)
     result: Result = runner.invoke(clean.main)
     assert "Error removing file " in result.output
     assert "Error removing directory " in result.output

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -324,15 +324,17 @@ def test_clean_errors(runner: CliRunner, tmp_path: Path) -> None:
         ),
     ]
 
-    matches: list[bool] = []
+    matches: list[bool] = [False] * len(expected_output)
+    i: int = 0
     for line in result.output.split("\n"):
-        if expected_output[len(matches)] in line:
-            matches.append(True)
-        if len(matches) >= len(expected_output):
+        if expected_output[i] in line:
+            matches[i] = True
+            i += 1
+        if i >= len(expected_output):
             break
     # If all elements of expected_output where found in result.output (in order), i
     # should equal length of expected_output
-    assert len(matches) == len(expected_output)
+    assert matches.count(True) == len(expected_output)
 
 
 def verify_tmp_path(path: Path) -> bool:

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,7 +1,4 @@
-import platform
-import stat
 from pathlib import Path
-import subprocess
 
 import pytest
 from click.testing import CliRunner, Result

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -324,14 +324,15 @@ def test_clean_errors(runner: CliRunner, tmp_path: Path) -> None:
         ),
     ]
 
-    i: int = 0
+    matches: list[bool] = []
     for line in result.output.split("\n"):
-        i += 1 if expected_output[i] in line else 0
-        if i >= len(expected_output):
+        if expected_output[len(matches)] in line:
+            matches.append(True)
+        if len(matches) >= len(expected_output):
             break
     # If all elements of expected_output where found in result.output (in order), i
     # should equal length of expected_output
-    assert i == len(expected_output)
+    assert len(matches) == len(expected_output)
 
 
 def verify_tmp_path(path: Path) -> bool:

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -170,6 +170,33 @@ def test_clean(runner: CliRunner, tmp_path: Path, args: tuple[str]) -> None:
     # Verfiy successive run doesn't break anything
     result: Result = runner.invoke(clean.main)
     assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "bad_args",
+    [
+        ("--log-level", ""),
+        ("-l", ""),
+        ("--log-level", "inf0"),
+        ("--log-level", "d3bug"),
+        ("--log-level", "3RR0R"),
+        ("log"),
+        ("bad"),
+    ]
+)
+def test_clean_bad_args(runner: CliRunner, tmp_path: Path, bad_args: tuple[str]) -> None:
+    """Test running `clean.py` with bad CLI arguments.
+
+    Args:
+        runner (CliRunner): Provides functionality to invoke a `click` command.
+        tmp_path (Path): Testing directory provided by `pytest`.
+        bad_args (tuple[str]): Tuple of invalid arguments.
+
+    """
+    # Verify tmp_path is not empty
+    assert verify_tmp_path(tmp_path)
+
+    result: Result = runner.invoke(clean.main, bad_args)
     assert result.exit_code != 0
 
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -297,6 +297,12 @@ def test_clean_errors(runner: CliRunner, tmp_path: Path) -> None:
     # Verify tmp_path is not empty
     assert verify_tmp_path(tmp_path)
 
+    new_dir: Path = tmp_path.joinpath("test_dir")
+    new_dir.mkdir()
+
+    original_dirs: list[str] = clean.DIRS_TO_CLEAN
+    clean.DIRS_TO_CLEAN.append(new_dir)
+
     # Create new file in a directory from DIRS_TO_CLEAN
     new_file: Path = tmp_path.joinpath(clean.DIRS_TO_CLEAN[0]).joinpath("test_file")
     new_file.touch()
@@ -307,11 +313,16 @@ def test_clean_errors(runner: CliRunner, tmp_path: Path) -> None:
     original_files: list[str] = clean.FILES_TO_CLEAN
     clean.FILES_TO_CLEAN.append(f"{new_file.parent.name}/{new_file.name}")
 
+    # TODO
+    Path.chmod(new_dir, 0o000)
+    Path.chmod(new_file, 0o000)
+
     # Run clean.py while new_file is open
-    with Path.open(new_file) as _:
-        result: Result = runner.invoke(clean.main, ["-l", "debug"])
+    # with Path.open(new_file) as _:
+    result: Result = runner.invoke(clean.main, ["-l", "debug"])
     assert result.exit_code == 0
 
+    clean.DIRS_TO_CLEAN = original_dirs
     clean.FILES_TO_CLEAN = original_files
 
     expected_output: list[str] = [

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -332,6 +332,7 @@ def test_clean_errors(runner: CliRunner, tmp_path: Path) -> None:
             i += 1
         if i >= len(expected_output):
             break
+    print(result.output)
     # If all elements of expected_output where found in result.output (in order), i
     # should equal length of expected_output
     assert matches.count(True) == len(expected_output)

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -197,18 +197,19 @@ def test_clean_swap_directory_with_file(
         assert f"{f}\" exists but is not a file." in result.output
 
 
-@pytest.mark.parametrize(
-    "",
-    [
-        (),
-        # rmv dir when ? (what causes error?)
-        #TODO
-        # rmv file when ? (what causes error?)
-        #TODO
-    ]
-)
-def test_clean_errors(
-    runner: CliRunner,
-    tmp_path: Path,
-) -> None:
-    pass
+#TODO
+# @pytest.mark.parametrize(
+#     "",
+#     [
+#         (),
+#         # rmv dir when ? (what causes error?)
+#         #TODO
+#         # rmv file when ? (what causes error?)
+#         #TODO
+#     ]
+# )
+# def test_clean_errors(
+#     runner: CliRunner,
+#     tmp_path: Path,
+# ) -> None:
+#     pass

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -260,18 +260,20 @@ def test_clean_swap_directory_with_file(
     """Test `clean.py` when directory swapped with file and vice versa.
 
     Args:
-        runner (CliRunner): ...
-        tmp_path (Path): ...
-        directories (list[str]): ...
-        files (list[str]): ...
+        runner (CliRunner): Provides functionality to invoke a `click` command.
+        tmp_path (Path): Testing directory provided by `pytest`.
+        directories (list[str]): List of "directory/ies" that are actually file/s.
+        files (list[str]): List of "file/s" that are actually directory/ies.
 
     """
-    assert any(tmp_path.iterdir())
+    # Verify tmp_path is not empty
+    assert verify_tmp_path(tmp_path)
 
-    clean.DIRS_TO_CLEAN, original_dirs = directories.copy(), clean.DIRS_TO_CLEAN
-    clean.FILES_TO_CLEAN, original_files = files.copy(), clean.FILES_TO_CLEAN
+    clean.DIRS_TO_CLEAN, original_dirs = directories, clean.DIRS_TO_CLEAN
+    clean.FILES_TO_CLEAN, original_files = files, clean.FILES_TO_CLEAN
 
     result: Result = runner.invoke(clean.main, ["-l", "debug"])
+    assert result.exit_code == 0
 
     clean.DIRS_TO_CLEAN = original_dirs
     clean.FILES_TO_CLEAN = original_files

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,0 +1,214 @@
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner, Result
+
+import scripts.clean as clean
+from scripts.clean import LogLevel
+
+
+@pytest.fixture(scope="function")
+def runner() -> CliRunner:
+    """Fixture to provide a CliRunner instance.
+
+    Returns:
+        CliRunner: instance of CliRunner class.
+
+    """
+    return CliRunner()
+
+
+@pytest.fixture(scope="function")
+def tmp_path(tmp_path: Path) -> Path:
+    """Provide `pytest`'s tmp_path with directories and files to clean.
+
+    Args:
+        tmp_path (Path): `pytest`'s tmp_path Path fixture.
+
+    Returns:
+        Path: tmp_path containing newly created directories and files.
+
+    """
+    directories: list[str] = clean.DIRS_TO_CLEAN.copy()
+    for d in directories:
+        tmp_path.joinpath(d).mkdir(parents=True)
+    files: list[str] = clean.FILES_TO_CLEAN.copy()
+    for f in files:
+        tmp_path.joinpath(f).touch()
+    clean.PROJECT_DIR = tmp_path
+    return tmp_path
+
+
+MESSAGES: dict[LogLevel, list[str]] = {
+    LogLevel.INFO: [
+        "Cleaning directory: ",
+        "Cleaning complete: ",
+        f"{len(clean.FILES_TO_CLEAN)} files, ",
+        f"{len(clean.DIRS_TO_CLEAN)} directories removed.",
+    ],
+    LogLevel.DEBUG: [
+        "Removing directory: ",
+        "Removing file: ",
+    ],
+}
+
+
+# Skip lint formatting of pytest.mark.parametrize block:
+# fmt: off
+@pytest.mark.parametrize(
+    "log_level, expected_list, unexpected_list",
+    [
+        (None,      MESSAGES[LogLevel.INFO], MESSAGES[LogLevel.DEBUG]),
+        ("debug",   MESSAGES[LogLevel.DEBUG] + MESSAGES[LogLevel.INFO], []),
+        ("info",    MESSAGES[LogLevel.INFO], MESSAGES[LogLevel.DEBUG]),
+        ("warning", [], MESSAGES[LogLevel.DEBUG] + MESSAGES[LogLevel.INFO]),
+        ("warn",    [], MESSAGES[LogLevel.DEBUG] + MESSAGES[LogLevel.INFO]),
+        ("error",   [], MESSAGES[LogLevel.DEBUG] + MESSAGES[LogLevel.INFO]),
+    ],
+)
+# fmt: on
+def test_logging(
+    runner: CliRunner,
+    tmp_path: Path,
+    log_level: str | None,
+    expected_list: list[str],
+    unexpected_list: list[str]
+) -> None:
+    """Test logging in `clean.py`.
+
+    Args:
+        runner (CliRunner): Provides functionality to invoke a `click` command.
+        tmp_path (Path): Testing directory provided by `pytest`.
+        log_level (str | None): Logging level to output at.
+        expected_list (list[str]): ...
+        unexpected_list (list[str]): ...
+
+    """
+    result: Result = (
+        runner.invoke(clean.main)
+        if log_level is None
+        else runner.invoke(clean.main, ["--log-level", log_level])
+    )
+    for expected in expected_list:
+        assert expected in result.output
+    for unexpected in unexpected_list:
+        assert unexpected not in result.output
+
+
+def test_clean(runner: CliRunner, tmp_path: Path) -> None:
+    """Test standard use of `clean.py`.
+
+    Args:
+        runner (CliRunner): Provides functionality to invoke a `click` command.
+        tmp_path (Path): Testing directory provided by `pytest`.
+
+    """
+    # Verify tmp_path is not empty
+    assert any(tmp_path.iterdir())
+
+    # Invoke clean.py CLI
+    runner.invoke(clean.main)
+
+    # Verify tmp_path removed correct directories and files
+    for item in tmp_path.iterdir():
+        assert item not in clean.DIRS_TO_CLEAN
+        assert item not in clean.FILES_TO_CLEAN
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "directories, files",
+    [
+        (["fake_dir"], ["fake_file"]),
+    ]
+)
+# fmt: on
+def test_clean_does_not_exist(
+    runner: CliRunner,
+    tmp_path: Path,
+    directories: list[str],
+    files: list[str]
+) -> None:
+    """Test `clean.py` when directory/file doesn't exist.
+
+    Args:
+        runner (CliRunner): ...
+        tmp_path (Path): ...
+        directories (list[str]): ...
+        files (list[str]): ...
+
+    """
+    assert any(tmp_path.iterdir())
+
+    clean.DIRS_TO_CLEAN, original_dirs = directories.copy(), clean.DIRS_TO_CLEAN
+    clean.FILES_TO_CLEAN, original_files = files.copy(), clean.FILES_TO_CLEAN
+
+    result: Result = runner.invoke(clean.main, ["-l", "debug"])
+
+    clean.DIRS_TO_CLEAN = original_dirs
+    clean.FILES_TO_CLEAN = original_files
+
+    assert len(directories) > 0
+    for d in directories:
+        assert f"{d}\" does not exist." in result.output
+    assert len(files) > 0
+    for f in files:
+        assert f"{f}\" does not exist." in result.output
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    "directories, files",
+    [
+        (clean.FILES_TO_CLEAN[:1], clean.DIRS_TO_CLEAN[:1]),
+    ]
+)
+# fmt: on
+def test_clean_swap_directory_with_file(
+    runner: CliRunner,
+    tmp_path: Path,
+    directories: list[str],
+    files: list[str]
+) -> None:
+    """Test `clean.py` when directory swapped with file and vice versa.
+
+    Args:
+        runner (CliRunner): ...
+        tmp_path (Path): ...
+        directories (list[str]): ...
+        files (list[str]): ...
+
+    """
+    assert any(tmp_path.iterdir())
+
+    clean.DIRS_TO_CLEAN, original_dirs = directories.copy(), clean.DIRS_TO_CLEAN
+    clean.FILES_TO_CLEAN, original_files = files.copy(), clean.FILES_TO_CLEAN
+
+    result: Result = runner.invoke(clean.main, ["-l", "debug"])
+
+    clean.DIRS_TO_CLEAN = original_dirs
+    clean.FILES_TO_CLEAN = original_files
+
+    assert len(directories) > 0
+    for d in directories:
+        assert f"{d}\" exists but is not a directory." in result.output
+    assert len(files) > 0
+    for f in files:
+        assert f"{f}\" exists but is not a file." in result.output
+
+
+@pytest.mark.parametrize(
+    "",
+    [
+        (),
+        # rmv dir when ? (what causes error?)
+        #TODO
+        # rmv file when ? (what causes error?)
+        #TODO
+    ]
+)
+def test_clean_errors(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    pass

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -158,7 +158,7 @@ def test_clean(runner: CliRunner, tmp_path: Path, args: tuple[str]) -> None:
     clean.FILES_TO_CLEAN = original_files
 
     # Invoke clean.py CLI under normal conditions
-    result: Result = runner.invoke(clean.main)
+    result = runner.invoke(clean.main)
     assert result.exit_code == 0
 
     # Verify tmp_path removed correct directories and files
@@ -168,7 +168,7 @@ def test_clean(runner: CliRunner, tmp_path: Path, args: tuple[str]) -> None:
         assert not tmp_path.joinpath(f).exists()
 
     # Verfiy successive run doesn't break anything
-    result: Result = runner.invoke(clean.main)
+    result = runner.invoke(clean.main)
     assert result.exit_code == 0
 
 

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,3 +1,4 @@
+import stat
 from pathlib import Path
 
 import pytest
@@ -197,19 +198,19 @@ def test_clean_swap_directory_with_file(
         assert f"{f}\" exists but is not a file." in result.output
 
 
-#TODO
-# @pytest.mark.parametrize(
-#     "",
-#     [
-#         (),
-#         # rmv dir when ? (what causes error?)
-#         #TODO
-#         # rmv file when ? (what causes error?)
-#         #TODO
-#     ]
-# )
-# def test_clean_errors(
-#     runner: CliRunner,
-#     tmp_path: Path,
-# ) -> None:
-#     pass
+def test_clean_errors(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """Test `clean.py` with directories/files lacking permission to delete.
+
+    Args:
+        runner (CliRunner): ...
+        tmp_path (Path): ...
+
+    """
+    for item in tmp_path.iterdir():
+        item.chmod(stat.S_IREAD)
+    result: Result = runner.invoke(clean.main)
+    assert "Error removing file " in result.output
+    assert "Error removing directory " in result.output

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -195,3 +195,25 @@ def test_clean_swap_directory_with_file(
     assert len(files) > 0
     for f in files:
         assert f"{f}\" exists but is not a file." in result.output
+
+
+def verify_tmp_path(path: Path) -> bool:
+    """Verify `pytest`'s `tmp_path` contains correct directories and files.
+
+    Args:
+        path (Path): `pytest`'s `tmp_path` fixture.
+
+    Returns:
+        bool: Returns `True` if `tmp_path` contains all correct directories and files.
+              Returns `False` otherwise.
+
+    """
+    # Concatenate DIRS_TO_CLEAN and FILES_TO_CLEAN into one list of items:
+    #     clean.DIRS_TO_CLEAN + clean.FILES_TO_CLEAN
+    # Create sequence from this concatenated list where each element is True if each item
+    # exists at least in one location in `path`:
+    #     any(path.rglob(item)) for item in clean.DIRS_TO_CLEAN + clean.FILES_TO_CLEAN
+    # return True if any of this sequence's elements is True, otherwise False:
+    return any(
+        any(path.rglob(item)) for item in clean.DIRS_TO_CLEAN + clean.FILES_TO_CLEAN
+    )

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -217,18 +217,20 @@ def test_clean_does_not_exist(
     """Test `clean.py` when directory/file doesn't exist.
 
     Args:
-        runner (CliRunner): ...
-        tmp_path (Path): ...
-        directories (list[str]): ...
-        files (list[str]): ...
+        runner (CliRunner): Provides functionality to invoke a `click` command.
+        tmp_path (Path): Testing directory provided by `pytest`.
+        directories (list[str]): List of non-existant directory/ies.
+        files (list[str]): List of non-existant file/s.
 
     """
-    assert any(tmp_path.iterdir())
+    # Verify tmp_path is not empty
+    assert verify_tmp_path(tmp_path)
 
-    clean.DIRS_TO_CLEAN, original_dirs = directories.copy(), clean.DIRS_TO_CLEAN
-    clean.FILES_TO_CLEAN, original_files = files.copy(), clean.FILES_TO_CLEAN
+    clean.DIRS_TO_CLEAN, original_dirs = directories, clean.DIRS_TO_CLEAN
+    clean.FILES_TO_CLEAN, original_files = files, clean.FILES_TO_CLEAN
 
     result: Result = runner.invoke(clean.main, ["-l", "debug"])
+    assert result.exit_code == 0
 
     clean.DIRS_TO_CLEAN = original_dirs
     clean.FILES_TO_CLEAN = original_files

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -1,5 +1,7 @@
+import platform
 import stat
 from pathlib import Path
+import subprocess
 
 import pytest
 from click.testing import CliRunner, Result
@@ -211,7 +213,8 @@ def test_clean_errors(
     """
     for item in tmp_path.iterdir():
         item.chmod(stat.S_IREAD)
-    tmp_path.chmod(stat.S_IREAD | stat.S_IEXEC)
+        if platform.system() != "Windows":
+            subprocess.run(["sudo", "chattr", "+i", item], check=True)
     result: Result = runner.invoke(clean.main)
     assert "Error removing file " in result.output
     assert "Error removing directory " in result.output

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -148,8 +148,8 @@ def test_clean(runner: CliRunner, tmp_path: Path, args: tuple[str]) -> None:
     assert verify_tmp_path(tmp_path)
 
     # Invoke clean.py CLI when clean.DIRS_TO_CLEAN and clean.FILES_TO_CLEAN are empty
-    clean.DIRS_TO_CLEAN, original_dirs = [], clean.DIRS_TO_CLEAN
-    clean.FILES_TO_CLEAN, original_files = [], clean.FILES_TO_CLEAN
+    clean.DIRS_TO_CLEAN, original_dirs = [], clean.DIRS_TO_CLEAN.copy()
+    clean.FILES_TO_CLEAN, original_files = [], clean.FILES_TO_CLEAN.copy()
 
     result: Result = runner.invoke(clean.main, args)
     assert result.exit_code == 0
@@ -226,8 +226,8 @@ def test_clean_does_not_exist(
     # Verify tmp_path is not empty
     assert verify_tmp_path(tmp_path)
 
-    clean.DIRS_TO_CLEAN, original_dirs = directories, clean.DIRS_TO_CLEAN
-    clean.FILES_TO_CLEAN, original_files = files, clean.FILES_TO_CLEAN
+    clean.DIRS_TO_CLEAN, original_dirs = directories, clean.DIRS_TO_CLEAN.copy()
+    clean.FILES_TO_CLEAN, original_files = files, clean.FILES_TO_CLEAN.copy()
 
     result: Result = runner.invoke(clean.main, ["-l", "debug"])
     assert result.exit_code == 0
@@ -269,8 +269,8 @@ def test_clean_swap_directory_with_file(
     # Verify tmp_path is not empty
     assert verify_tmp_path(tmp_path)
 
-    clean.DIRS_TO_CLEAN, original_dirs = directories, clean.DIRS_TO_CLEAN
-    clean.FILES_TO_CLEAN, original_files = files, clean.FILES_TO_CLEAN
+    clean.DIRS_TO_CLEAN, original_dirs = directories, clean.DIRS_TO_CLEAN.copy()
+    clean.FILES_TO_CLEAN, original_files = files, clean.FILES_TO_CLEAN.copy()
 
     result: Result = runner.invoke(clean.main, ["-l", "debug"])
     assert result.exit_code == 0

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -198,23 +198,3 @@ def test_clean_swap_directory_with_file(
     assert len(files) > 0
     for f in files:
         assert f"{f}\" exists but is not a file." in result.output
-
-
-def test_clean_errors(
-    runner: CliRunner,
-    tmp_path: Path,
-) -> None:
-    """Test `clean.py` with directories/files lacking permission to delete.
-
-    Args:
-        runner (CliRunner): ...
-        tmp_path (Path): ...
-
-    """
-    for item in tmp_path.iterdir():
-        item.chmod(stat.S_IREAD)
-        if platform.system() != "Windows":
-            subprocess.run(["sudo", "chattr", "+i", item], check=True)
-    result: Result = runner.invoke(clean.main)
-    assert "Error removing file " in result.output
-    assert "Error removing directory " in result.output

--- a/tests/test_pyproject_init.py
+++ b/tests/test_pyproject_init.py
@@ -56,7 +56,6 @@ def test_new_command_creates_project(runner: CliRunner, tmp_path: Path) -> None:
     result = runner.invoke(
         cli, ["new", project_name, "--output-dir", str(output_dir), "--no-input"]
     )
-    # import pdb; pdb.set_trace()
 
     # Assertions
     assert result.exit_code == 0


### PR DESCRIPTION
- [X] Create `test_clean.py`
- [x] Explicitly check that each file/directory doesn't exist after running clean in test_clean()
- [x] ~~Make string-matching more general in test_clean_does_not_exist() and test_clean_swap()~~
    > I'm content with how this is being checked for now
- [x] Add `assert result.exit_code == 0`
- [x] Check for correct sequence in test_logging()
- [x] Confirm permission error can't be done (test_clean_errors)
- [x] Add test when DIRS_TO_CLEAN and/or FILES_TO_CLEAN are empty
- [x] Pass invalid CLI arguments
- [x] Run clean() twice to confirm it doesn't fail the second time
- [x] ~~Add test(s) for clean log file~~
    > This is a large enough addition for it's own Issue

Closes #3